### PR TITLE
feat: add support for logged in users

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ export interface PluginOptions {
   amplitudeApiKey: string;
   segmentInstance: AnalyticsBrowser;
   sessionReplayOptions: SessionReplayOptions;
-  deviceId?: string;
 }
 
 export type AmplitudeIntegrationData = {


### PR DESCRIPTION
Update the plugin to support use of the `userId` if present, following the guidance in this [Best Practices documentation from Segment](https://segment.com/docs/connections/spec/best-practices-identify/)