### PR TITLE
fix: use anonymous id as device id

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -50,7 +50,7 @@ export const createSegmentActionsPlugin = async ({
     isLoaded: () => true,
     load: async (_ctx, ajs) => {
       const user = ajs.user();
-      const deviceId = user.id() || user.anonymousId();
+      const deviceId = user.anonymousId();
       const storedSessionId = getStoredSessionId();
 
       await sessionReplay.init(amplitudeApiKey, {


### PR DESCRIPTION
We got feedback from customers that we should only use the anonymous id for now, otherwise the device id passed to SR changes midsession when a user logs in, which may create issues in playback. We may also need to support an option to allow customers to set their own device id at some point, but we won't handle that just yet.